### PR TITLE
Remove calls to Console.WriteLine() from finalizers in tests.

### DIFF
--- a/tests/src/JIT/Methodical/explicit/basic/refloc_c.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refloc_c.il
@@ -32,8 +32,6 @@
     {
       // Code size       59 (0x3b)
       .maxstack  8
-      IL_0000:  ldstr      "finalizer called."
-      IL_0005:  call       void [System.Console]System.Console::WriteLine(class System.String)
       IL_000a:  ldarg.0
       IL_0027:  ldfld      wchar Test.AA::mm
       			ldc.i4 84

--- a/tests/src/JIT/Methodical/explicit/basic/refloc_i1.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refloc_i1.il
@@ -32,8 +32,6 @@
     {
       // Code size       59 (0x3b)
       .maxstack  8
-      IL_0000:  ldstr      "finalizer called."
-      IL_0005:  call       void [System.Console]System.Console::WriteLine(class System.String)
       IL_000a:  ldarg.0
       IL_0027:  ldfld      unsigned int8 Test.AA::mm
       			ldc.i4 45

--- a/tests/src/JIT/Methodical/explicit/basic/refloc_i2.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refloc_i2.il
@@ -32,8 +32,6 @@
     {
       // Code size       59 (0x3b)
       .maxstack  8
-      IL_0000:  ldstr      "finalizer called."
-      IL_0005:  call       void [System.Console]System.Console::WriteLine(class System.String)
       IL_000a:  ldarg.0
       IL_0027:  ldfld      int16 Test.AA::mm
       			ldc.i4 -45

--- a/tests/src/JIT/Methodical/explicit/basic/refloc_i4.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refloc_i4.il
@@ -32,8 +32,6 @@
     {
       // Code size       59 (0x3b)
       .maxstack  8
-      IL_0000:  ldstr      "finalizer called."
-      IL_0005:  call       void [System.Console]System.Console::WriteLine(class System.String)
       IL_000a:  ldarg.0
       IL_0027:  ldfld      int32 Test.AA::mm
       			ldc.i4 45

--- a/tests/src/JIT/Methodical/explicit/basic/refloc_o.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refloc_o.il
@@ -64,9 +64,6 @@
       // Code size       60 (0x3c)
       .maxstack  2
       .locals (class Test.AA V_0)
-      IL_0000:  ldstr      "finalizer called."
-      IL_0005:  call       void [System.Console]System.Console::WriteLine(class System.String)
-
       IL_0035:  ldc.i4.1
       IL_0036:  stsfld     bool Test.AA::finalizerCalled
       IL_003b:  ret

--- a/tests/src/JIT/Methodical/explicit/basic/refloc_o2.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refloc_o2.il
@@ -65,8 +65,6 @@
       // Code size       60 (0x3c)
       .maxstack  3
       .locals (class Test.AA V_0)
-      IL_0000:  ldstr      "finalizer called."
-      IL_0005:  call       void [System.Console]System.Console::WriteLine(class System.String)
       
       all_done: ldc.i4.1
       

--- a/tests/src/JIT/Methodical/explicit/basic/refloc_r4.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refloc_r4.il
@@ -34,8 +34,6 @@
     {
       // Code size       101 (0x65)
       .maxstack  2
-      IL_0000:  ldstr      "finalizer called."
-      IL_0005:  call       void [System.Console]System.Console::WriteLine(class System.String)
       IL_000a:  ldarg.0
       IL_0051:  ldfld      float32 Test.AA::mm
       			ldc.r4     45.119999

--- a/tests/src/JIT/Methodical/explicit/basic/refloc_r8.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refloc_r8.il
@@ -32,8 +32,6 @@
     {
       // Code size       59 (0x3b)
       .maxstack  8
-      IL_0000:  ldstr      "finalizer called."
-      IL_0005:  call       void [System.Console]System.Console::WriteLine(class System.String)
       IL_000a:  ldarg.0
       IL_0027:  ldfld      float64 Test.AA::mm
       			ldc.r8     -45.119999999999997

--- a/tests/src/JIT/Methodical/explicit/basic/refloc_u2.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refloc_u2.il
@@ -32,8 +32,6 @@
     {
       // Code size       61 (0x3d)
       .maxstack  8
-      IL_0000:  ldstr      "finalizer called."
-      IL_0005:  call       void [System.Console]System.Console::WriteLine(class System.String)
       IL_000a:  ldarg.0
       IL_0028:  ldfld      unsigned int16 Test.AA::mm
       IL_002d:  conv.i4


### PR DESCRIPTION
If these lose the race with Console finalization they throw a "System.NotSupportedException: Stream does not support writing" on Mono (since at least v4.16)

I didn't bother fixing IL offset labels because they are already wrong for that method